### PR TITLE
Prevent order status corruption on repeat ENS calls

### DIFF
--- a/Model/Order/Action/Decline.php
+++ b/Model/Order/Action/Decline.php
@@ -119,10 +119,17 @@ class Decline implements ActionInterface
      */
     protected function setOrderStatusDecline(Order $order)
     {
+        $orderState = $order->getHoldBeforeState();
+        $orderStatus = $order->getHoldBeforeStatus();
+        if ($orderState === Order::STATE_HOLDED && $orderStatus === OrderRis::STATUS_KOUNT_DECLINE) {
+            $this->logger->info('Setting order to Kount Decline status/state - already set, skipping');
+            return;
+        }
+        
         $this->logger->info('Setting order to Kount Decline status/state');
 
-        $order->setHoldBeforeState($order->getState());
-        $order->setHoldBeforeStatus($order->getStatus());
+        $order->setHoldBeforeState($orderState);
+        $order->setHoldBeforeStatus($orderStatus);
 
         $order->setState(Order::STATE_HOLDED);
         $order->addStatusToHistory(OrderRis::STATUS_KOUNT_DECLINE, __('Order declined from Kount.'), false);

--- a/Model/Order/Action/Restore.php
+++ b/Model/Order/Action/Restore.php
@@ -28,10 +28,17 @@ class Restore implements ActionInterface
      */
     public function process($order)
     {
+        $orderState = $order->getHoldBeforeState();
+        $orderStatus = $order->getHoldBeforeStatus();
+        if (!$orderState || !$orderStatus) {
+            $this->logger->info('Restore order status/state by ENS Kount request - incomplete data, skipping');
+            return;
+        }
+        
         $this->logger->info('Restore order status/state by ENS Kount request.');
 
-        $order->setState($order->getHoldBeforeState());
-        $order->addStatusToHistory($order->getHoldBeforeStatus(), __('Order status updated from Kount.'), false);
+        $order->setState($orderState);
+        $order->addStatusToHistory($orderStatus, __('Order status updated from Kount.'), false);
 
         $order->setHoldBeforeState(null);
         $order->setHoldBeforeStatus(null);

--- a/Model/Order/Action/Review.php
+++ b/Model/Order/Action/Review.php
@@ -30,10 +30,17 @@ class Review implements ActionInterface
      */
     public function process($order)
     {
+        $orderState = $order->getState();
+        $orderStatus = $order->getStatus();
+        if ($orderState === Order::STATE_HOLDED && $orderStatus === OrderRis::STATUS_KOUNT_REVIEW) {
+            $this->logger->info('Setting order to Kount Review status/state - already set, skipping');
+            return;
+        }
+
         $this->logger->info('Setting order to Kount Review status/state');
 
-        $order->setHoldBeforeState($order->getState());
-        $order->setHoldBeforeStatus($order->getStatus());
+        $order->setHoldBeforeState($orderState);
+        $order->setHoldBeforeStatus($orderStatus);
 
         $order->setState(Order::STATE_HOLDED);
         $order->addStatusToHistory(OrderRis::STATUS_KOUNT_REVIEW, __('Order on review from Kount.'), false);


### PR DESCRIPTION
For some reason, sometimes Kount duplicates order hold ENS calls, particularly setting order Status = Review. On the 2nd call the "hold before" fields storing the state/status before the hold lose their value and get overwritten with Hold/Review. Such orders remain stuck in the Review status because the restore ENS call updates Review to Review while also resetting the "hold before" fields. After that, when a Magento admin user tries to Unhold the order, it loses its state/status entirely because of "restoring" from the empty "hold before" fields.

This PR implements protection from the orders status corruption upon repeat ENS calls.